### PR TITLE
bumped the module version to match the new repo version 1.1.1

### DIFF
--- a/PoSh-Ohai.psd1
+++ b/PoSh-Ohai.psd1
@@ -19,7 +19,7 @@
 RootModule = 'PoSh-Ohai.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1'
+ModuleVersion = '1.1.1'
 
 # ID used to uniquely identify this module
 GUID = '24c4a4b0-a95f-4b20-8118-3846d22c88f1'


### PR DESCRIPTION
Closes #53 

Matching module version to repo version. This will allow the deploy.ps1 to always download the latest version of the module.